### PR TITLE
Removing the master and slave lingo

### DIFF
--- a/autodbperftool/ADT/common.py
+++ b/autodbperftool/ADT/common.py
@@ -35,7 +35,7 @@ class CommonActions(object):
     password      = None
     instance_type = None # indicate whether the instance is RDS or database on VM host
     db_version    = None # database version, e.g.: mysql5.5, mysql5.6 ...
-    db_setup      = None # including three types: 1.default; 2.high-safety (slave-master); 3.high-performance;
+    db_setup      = None # including three types: 1.default; 2.high-safety (subordinate-main); 3.high-performance;
     long_stand    = None # indicate whether the test is long-stand testing, default is False 
     
     'sysbench params fields'


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.